### PR TITLE
Corrected the Indentation in the pubspec.Yaml file...

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,4 @@ flutter:
   uses-material-design: true
 
   assets:
-  - images/
+    - images/


### PR DESCRIPTION
According to the Official Documentation available on the Internet , there should be two spaces before the hyphen in the pubspec.yaml file . I was stuck at this for many hours  , I think the previous indentation manner is'nt compatible with the latest version of flutter 